### PR TITLE
chore: add pre-push hook to block direct main pushes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  echo "❌ Direct push to $branch is blocked. Use a feature branch and PR."
+  exit 1
+fi


### PR DESCRIPTION
Adds .githooks/pre-push that blocks direct pushes to main/master.