### PR TITLE
chore: sync storybook local dev port to /etc/hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "node scripts/prepublish-check.mjs && pnpm build",
-    "storybook": "storybook dev -p 21470",
+    "storybook": "storybook dev -p 61472",
     "build-storybook": "STORYBOOK_BASE=/storybook/ storybook build -o storybook-static"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Updates storybook script port from `21470` to `61472` to match the `/etc/hosts` assignment for `vedic-icons-storybook.yantrakit.local`.

## Test plan
- [ ] `pnpm storybook` listens on port 61472