### PR TITLE
chore: merge chore/sync-local-dev-ports → main (storybook port → 42491)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "node scripts/prepublish-check.mjs && pnpm build",
-    "storybook": "storybook dev -p 61472",
+    "storybook": "storybook dev -p 42491",
     "build-storybook": "STORYBOOK_BASE=/storybook/ storybook build -o storybook-static"
   },
   "devDependencies": {


### PR DESCRIPTION
Port fix per new YK universe NOT connected allocation. Storybook port for the vedic-icons npm package is now 42491 to match the YK universe entry in hosts.txt (vedic-icons.yantrakit.local 41491).